### PR TITLE
Spark fun

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Spark Tools #
 
-[![Maven Central](https://img.shields.io/maven-central/v/org.tupol/spark-tools_2.11.svg)](https://mvnrepository.com/artifact/org.tupol/spark-tools) &nbsp;
-[![GitHub](https://img.shields.io/github/license/tupol/spark-tools.svg)](https://github.com/tupol/spark-tools/blob/master/LICENSE) &nbsp; 
-[![Travis (.org)](https://img.shields.io/travis/tupol/spark-tools.svg)](https://travis-ci.com/tupol/spark-tools) &nbsp; 
-[![Codecov](https://img.shields.io/codecov/c/github/tupol/spark-tools.svg)](https://codecov.io/gh/tupol/spark-tools) &nbsp;
-[![Javadocs](https://www.javadoc.io/badge/org.tupol/spark-tools_2.11.svg)](https://www.javadoc.io/doc/org.tupol/spark-tools_2.11) &nbsp;
-[![Gitter](https://badges.gitter.im/spark-tools/community.svg)](https://gitter.im/spark-tools/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge) &nbsp; 
-[![Twitter](https://img.shields.io/twitter/url/https/_tupol.svg?color=%2317A2F2)](https://twitter.com/_tupol) &nbsp; 
+[![Maven Central](https://img.shields.io/maven-central/v/org.tupol/spark-tools_2.11.svg)][maven-central] &nbsp;
+[![GitHub](https://img.shields.io/github/license/tupol/spark-tools.svg)][license] &nbsp; 
+[![Travis (.org)](https://img.shields.io/travis/tupol/spark-tools.svg)][travis.org] &nbsp; 
+[![Codecov](https://img.shields.io/codecov/c/github/tupol/spark-tools.svg)][codecov] &nbsp;
+[![Javadocs](https://www.javadoc.io/badge/org.tupol/spark-tools_2.11.svg)][javadocs] &nbsp;
+[![Gitter](https://badges.gitter.im/spark-tools/community.svg)][gitter] &nbsp; 
+[![Twitter](https://img.shields.io/twitter/url/https/_tupol.svg?color=%2317A2F2)][twitter] &nbsp; 
 
 ## Description ##
 This project contains some basic runnable tools that can help with various tasks around a Spark based project.
@@ -20,17 +20,22 @@ The main tools available:
   stream format into a different data stream format, providing also partitioning support.
 - [SimpleFileStreamingSqlProcessor](docs/file-streaming-sql-processor.md) Applies a given SQL to the input files streams which are being mapped into file output streams.
 
+This project is also trying to create and encourage a friendly yet professional environment 
+for developers to help each other, so please do no be shy and join through [gitter], [twitter], 
+[issue reports](https://github.com/tupol/spark-tools/issues/new/choose) or pull requests.
+
 
 ## Prerequisites ##
 
 * Java 6 or higher
 * Scala 2.11 or 2.12
-* Apache Spark 2.3.X
+* Apache Spark 2.3.X or higher
 
 
 ## Getting Spark Tools ##
 
-Spark Tools is published to Sonatype OSS and [Maven Central](https://mvnrepository.com/artifact/org.tupol/spark-tools),
+Spark Tools is published to [Maven Central][maven-central] and [Spark Packages][spark-packages]:
+
 where the latest artifacts can be found.
 
 - Group id / organization: `org.tupol`
@@ -42,6 +47,12 @@ Usage with SBT, adding a dependency to the latest version of tools to your sbt b
 ```scala
 libraryDependencies += "org.tupol" %% "spark-tools" % "0.3.0"
 ```
+
+Include this package in your Spark Applications using `spark-shell` or `spark-submit`
+```bash
+$SPARK_HOME/bin/spark-shell --packages org.tupol:spark-tools_2.11:0.3.0
+```
+
 
 ## What's new? ##
 
@@ -58,21 +69,21 @@ libraryDependencies += "org.tupol" %% "spark-tools" % "0.3.0"
 - Added `StreamingFormatConverter`
 - Added `FileStreamingSqlProcessor`, `SimpleFileStreamingSqlProcessor`
 
-**0.2.1**
-
-- Started using `spark-utils` `0.3.1` to benefit from variable substitution
-
-**0.2.0**
-
-- Started using `spark-utils` `0.3.0` and made the necessary API changes
-
-**0.1.0**
-
-- Added `FormatConverter`
-- Added `SqlProcessor` base class
-- Added `SimpleSqlProcessor` implementation
-
+For previous versions please consult the [release notes](RELEASE-NOTES.md).
 
 ## License ##
 
 This code is open source software licensed under the [MIT License](LICENSE).
+
+
+
+[scala]: https://scala-lang.org/
+[spark]: https://spark.apache.org/
+[maven-central]: https://mvnrepository.com/artifact/org.tupol/spark-tools
+[spark-packages]: https://spark-packages.org/package/tupol/spark-tools
+[license]: https://github.com/tupol/spark-tools/blob/master/LICENSE
+[travis.org]: https://travis-ci.com/tupol/spark-tools 
+[codecov]: https://codecov.io/gh/tupol/spark-tools
+[javadocs]: https://www.javadoc.io/doc/org.tupol/spark-tools_2.11
+[gitter]: https://gitter.im/spark-tools/community
+[twitter]: https://twitter.com/_tupol

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,0 +1,35 @@
+# Release Notes
+
+
+## 0.4.0
+
+- Added the `StreamingConfiguration` marker trait
+- Added `GenericStreamDataSource`, `FileStreamDataSource` and `KafkaStreamDataSource`
+- Added `GenericStreamDataSink`, `FileStreamDataSink` and `KafkaStreamDataSink`
+- Added `FormatAwareStreamingSourceConfiguration` and `FormatAwareStreamingSinkConfiguration`
+- Extracted `TypesafeConfigBuilder`
+- API Changes: Added a new type parameter to the `DataSink` that describes the type of the output
+- Improved unit test coverage
+
+
+## 0.3.0
+
+- Package `processors` was renamed to `tools`
+- `SqlProcessor.registerSqlFunctions` takes now implicit parameters: spark session and 
+  application context
+- Added `StreamingFormatConverter`
+- Added `FileStreamingSqlProcessor`, `SimpleFileStreamingSqlProcessor`
+
+## 0.2.1
+
+- Started using `spark-utils` `0.3.1` to benefit from variable substitution
+
+## 0.2.0
+
+- Started using `spark-utils` `0.3.0` and made the necessary API changes
+
+## 0.1.0
+
+- Added `FormatConverter`
+- Added `SqlProcessor` base class
+- Added `SimpleSqlProcessor` implementation

--- a/build.sbt
+++ b/build.sbt
@@ -4,10 +4,11 @@ organization := "org.tupol"
 
 scalaVersion := "2.11.12"
 
-val sparkUtilsVersion = "0.4.0"
-val sparkVersion = "2.3.2"
+val sparkUtilsVersion = "0.4.1-SNAPSHOT"
+val sparkVersion = "2.4.3"
 val sparkXmlVersion = "0.4.1"
 val sparkAvroVersion = "4.0.0"
+val deltaVersion = "0.3.0"
 
 // ------------------------------
 // DEPENDENCIES AND RESOLVERS
@@ -16,14 +17,11 @@ updateOptions := updateOptions.value.withCachedResolution(true)
 resolvers += "Sonatype OSS Releases" at "https://oss.sonatype.org/content/repositories/releases"
 resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
 
-
 lazy val providedDependencies = Seq(
   "org.apache.spark" %% "spark-core" % sparkVersion force(),
   "org.apache.spark" %% "spark-sql" % sparkVersion force(),
   "org.apache.spark" %% "spark-mllib" % sparkVersion force(),
-  "org.apache.spark" %% "spark-streaming" % sparkVersion force(),
-  "com.databricks" %% "spark-xml" % sparkXmlVersion,
-  "com.databricks" %% "spark-avro" % sparkAvroVersion
+  "org.apache.spark" %% "spark-streaming" % sparkVersion force()
 )
 
 libraryDependencies ++= providedDependencies.map(_ % "provided")
@@ -33,8 +31,10 @@ libraryDependencies ++= Seq(
   "org.tupol" %% "spark-utils" % sparkUtilsVersion % "test" classifier "tests",
   "org.scalacheck" %% "scalacheck" % "1.14.0" % "test",
   "org.scalatest" %% "scalatest" % "3.0.5" % "test",
+  "org.apache.spark" %% "spark-avro" % sparkVersion % "test",
   "com.databricks" %% "spark-xml" % sparkXmlVersion % "test",
-  "com.databricks" %% "spark-avro" % sparkAvroVersion % "test"
+  "com.databricks" %% "spark-avro" % sparkAvroVersion % "test",
+  "io.delta" %% "delta-core" % deltaVersion % "test"
 )
 
 // ------------------------------

--- a/build.sbt
+++ b/build.sbt
@@ -21,14 +21,20 @@ lazy val providedDependencies = Seq(
   "org.apache.spark" %% "spark-core" % sparkVersion force(),
   "org.apache.spark" %% "spark-sql" % sparkVersion force(),
   "org.apache.spark" %% "spark-mllib" % sparkVersion force(),
-  "org.apache.spark" %% "spark-streaming" % sparkVersion force()
+  "org.apache.spark" %% "spark-streaming" % sparkVersion force(),
+  "org.apache.spark" %% "spark-sql-kafka-0-10" % sparkVersion,
+  "org.apache.spark" %% "spark-streaming-kafka-0-10" % sparkVersion
 )
 
 libraryDependencies ++= providedDependencies.map(_ % "provided")
 
+// Jackson dependencies over Spark and Kafka Versions can be tricky; for Spark 2.4.x we need this override
+dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-databind" % "2.6.7"
+
 libraryDependencies ++= Seq(
   "org.tupol" %% "spark-utils" % sparkUtilsVersion,
   "org.tupol" %% "spark-utils" % sparkUtilsVersion % "test" classifier "tests",
+  "net.manub" %% "scalatest-embedded-kafka" % "2.0.0" % "test",
   "org.scalacheck" %% "scalacheck" % "1.14.0" % "test",
   "org.scalatest" %% "scalatest" % "3.0.5" % "test",
   "org.apache.spark" %% "spark-avro" % sparkVersion % "test",

--- a/src/main/scala/org/tupol/spark/tools/FormatConverter.scala
+++ b/src/main/scala/org/tupol/spark/tools/FormatConverter.scala
@@ -23,9 +23,8 @@ SOFTWARE.
 */
 package org.tupol.spark.tools
 
-import com.typesafe.config.Config
 import org.apache.spark.sql.{ DataFrame, SparkSession }
-import org.tupol.spark.SparkApp
+import org.tupol.spark.SparkFun
 import org.tupol.spark.implicits._
 import org.tupol.spark.io._
 import org.tupol.utils.config.Configurator
@@ -42,11 +41,11 @@ import org.tupol.utils.config.Configurator
  *      [[https://spark.apache.org/docs/2.1.1/api/java/org/apache/spark/sql/DataFrameReader.html#json(java.lang.String...)]]</li>
  *  <li>For the AVRO converter see more details here:
  *      [[https://github.com/databricks/spark-avro]]</li>
+ *  <li>For the DELTA converter see more details here:
+ *      [[https://github.com/delta-io/delta]]</li>
  * </ul>
  */
-object FormatConverter extends SparkApp[FormatConverterContext, DataFrame] {
-
-  override def createContext(config: Config): FormatConverterContext = FormatConverterContext(config).get
+object FormatConverter extends SparkFun[FormatConverterContext, DataFrame](FormatConverterContext(_).get) {
 
   override def run(implicit spark: SparkSession, context: FormatConverterContext): DataFrame = {
     val inputData = spark.source(context.input).read

--- a/src/test/scala/org/tupol/spark/tools/FileStreamingSqlProcessorContextSpec.scala
+++ b/src/test/scala/org/tupol/spark/tools/FileStreamingSqlProcessorContextSpec.scala
@@ -1,0 +1,128 @@
+package org.tupol.spark.tools
+
+import com.typesafe.config.ConfigFactory
+import org.scalatest.{ FunSuite, Matchers }
+import org.tupol.spark.SharedSparkSession
+import org.tupol.spark.io.FormatType.Json
+import org.tupol.spark.io.sources.JsonSourceConfiguration
+import org.tupol.spark.io.streaming.structured.{ FileStreamDataSinkConfiguration, FileStreamDataSourceConfiguration, GenericStreamDataSinkConfiguration }
+import org.tupol.spark.sql.loadSchemaFromFile
+import org.tupol.spark.testing.files.TestTempFilePath1
+
+import scala.util.Failure
+
+class FileStreamingSqlProcessorContextSpec extends FunSuite with Matchers with SharedSparkSession with TestTempFilePath1 {
+
+  val ReferenceSchema = loadSchemaFromFile("src/test/resources/sources/avro/sample_schema.json")
+
+  test("Load configuration with external sql local path even if sql.line is specified") {
+
+    val config = ConfigFactory.parseString(
+      """
+        |  input: {
+        |    # It contains a map of table names that need to be associated with the files
+        |    tables {
+        |     "table1": {
+        |        path: "../../../src/test/resources/SqlProcessor/file1.json",
+        |        format: "json"
+        |     },
+        |     "table2": {
+        |        path: "../../../src/test/resources/SqlProcessor/file2.json",
+        |        format: "json"
+        |      }
+        |    }
+        |    variables {
+        |       table_name: "table1"
+        |       columns: "*"
+        |    }
+        |
+        |    # The query that will be applied on the input tables; the results will be saved into the SqlProcessor.output.path file
+        |    # The query must be written on a single line.
+        |    # All quotes must be escaped.
+        |    sql.line:"SELECT * FROM table1 where table1.id=\"1002\""
+        |    sql.path: "src/test/resources/SqlProcessor/test.sql"
+        |  }
+        |  output: {
+        |    # The path where the results will be saved
+        |    path: "/tmp/tests/test.json",
+        |    # The format of the output file; acceptable values are "json", "avro", FormatType.Json and "parquet"
+        |    format: "json",
+        |    # The output partition columns
+        |    partition.columns: ["id", "timestamp"]
+        |  }
+      """.stripMargin
+    )
+
+    val expectedInputTables = Map(
+      "table1" -> FileStreamDataSourceConfiguration(
+        "../../../src/test/resources/SqlProcessor/file1.json", JsonSourceConfiguration()
+      ),
+      "table2" -> FileStreamDataSourceConfiguration(
+        "../../../src/test/resources/SqlProcessor/file2.json", JsonSourceConfiguration()
+      )
+    )
+
+    val expectedSql =
+      """-- Some comment
+        |SELECT *
+        |-- Some other comment
+        |FROM table1
+        |WHERE
+        |-- Some filter comment
+        |table1.id="1001"""".stripMargin
+
+    val expectedVariables = Map("table_name" -> "table1", "columns" -> "*")
+
+    val expectedSink = FileStreamDataSinkConfiguration(
+      "/tmp/tests/test.json",
+      GenericStreamDataSinkConfiguration(format = Json, partitionColumns = Seq("id", "timestamp"))
+    )
+    val expected = FileStreamingSqlProcessorContext(expectedInputTables, expectedVariables, expectedSink, expectedSql)
+
+    FileStreamingSqlProcessorContext(config).get shouldBe expected
+
+  }
+
+  test("Load configuration fails if neither sql.line nor sql.path are specified") {
+
+    val config = ConfigFactory.parseString(
+      """
+        |  input: {
+        |    # It contains a map of table names that need to be associated with the files
+        |    tables {
+        |     "table1": {
+        |        path: "../../../src/test/resources/SqlProcessor/file1.json",
+        |        format: "json"
+        |     },
+        |     "table2": {
+        |        path: "../../../src/test/resources/SqlProcessor/file2.json",
+        |        format: "json"
+        |      }
+        |    }
+        |    variables {
+        |       table_name: "table1"
+        |       columns: "*"
+        |    }
+        |
+        |    # The query that will be applied on the input tables; the results will be saved into the SqlProcessor.output.path file
+        |    # The query must be written on a single line.
+        |    # All quotes must be escaped.
+        |    # sql.line:"SELECT * FROM table1 where table1.id=\"1002\""
+        |    # sql.path: "src/test/resources/SqlProcessor/test.sql"
+        |  }
+        |  output: {
+        |    # The path where the results will be saved
+        |    path: "/tmp/tests/test.json",
+        |    # The format of the output file; acceptable values are "json", "avro", FormatType.Json and "parquet"
+        |    format: "json",
+        |    # The output partition columns
+        |    partition.columns: ["id", "timestamp"]
+        |  }
+      """.stripMargin
+    )
+
+    FileStreamingSqlProcessorContext(config) shouldBe a[Failure[_]]
+
+  }
+
+}

--- a/src/test/scala/org/tupol/spark/tools/SimpleFileStreamingSqlProcessorSpec.scala
+++ b/src/test/scala/org/tupol/spark/tools/SimpleFileStreamingSqlProcessorSpec.scala
@@ -1,0 +1,96 @@
+package org.tupol.spark.tools
+
+import java.io.File
+
+import org.apache.commons.io.FileUtils
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.streaming.Trigger
+import org.scalatest.concurrent.Eventually
+import org.scalatest.time.{ Seconds, Span }
+import org.scalatest.{ BeforeAndAfter, FunSuite, GivenWhenThen, Matchers }
+import org.tupol.spark.SharedSparkSession
+import org.tupol.spark.io.FormatType
+import org.tupol.spark.io.sources.JsonSourceConfiguration
+import org.tupol.spark.io.streaming.structured._
+import org.tupol.spark.sql._
+import org.tupol.spark.testing.files.{ TestTempFilePath1, TestTempFilePath2 }
+
+import scala.util.Random
+
+class SimpleFileStreamingSqlProcessorSpec extends FunSuite
+  with Matchers with GivenWhenThen with Eventually with BeforeAndAfter
+  with SharedSparkSession with TestTempFilePath1 with TestTempFilePath2 {
+
+  implicit override val patienceConfig = PatienceConfig(timeout = scaled(Span(10, Seconds)))
+
+  test("FileStreamingSqlProcessor SELECT *") {
+
+    FileUtils.forceMkdir(testFile1)
+
+    val inputConfig1 = FileStreamDataSourceConfiguration(
+      testPath1,
+      JsonSourceConfiguration(
+        Map[String, String](),
+        Some(schemaFor[TestValueRecord])
+      )
+    )
+    val inputTables = Map("table1" -> inputConfig1)
+    val testSQL = "SELECT * FROM table1"
+    val genericSinkConfig = GenericStreamDataSinkConfiguration(FormatType.Json, Map(), None,
+      Some(Trigger.ProcessingTime("1 second")))
+    val sinkConfig = FileStreamDataSinkConfiguration(FormatType.Text, testPath2, genericSinkConfig, Some(testPath2))
+
+    implicit val config = FileStreamingSqlProcessorContext(inputTables, Map(), sinkConfig, testSQL)
+
+    val (streamingQuery, _) = SimpleFileStreamingSqlProcessor.run
+
+    val testMessages = (1 to 4).map(i => f"""{"value": "test-message-$i%02d"} """)
+    testMessages.foreach { message => addFile(message, testFile1) }
+
+    eventually {
+      val writtenData: DataFrame = spark.read.json(testPath2)
+      writtenData.count() shouldBe 4
+    }
+
+    streamingQuery.stop
+  }
+
+  test("FileStreamingSqlProcessor SELECT * WHERE") {
+
+    FileUtils.forceMkdir(testFile1)
+
+    val inputConfig1 = FileStreamDataSourceConfiguration(
+      testPath1,
+      JsonSourceConfiguration(
+        Map[String, String](),
+        Some(schemaFor[TestValueRecord])
+      )
+    )
+    val inputTables = Map("table1" -> inputConfig1)
+    val testSQL = "SELECT * FROM table1 WHERE value LIKE 'test-%-03'"
+    val genericSinkConfig = GenericStreamDataSinkConfiguration(FormatType.Json, Map(), None,
+      Some(Trigger.ProcessingTime("1 second")))
+    val sinkConfig = FileStreamDataSinkConfiguration(FormatType.Text, testPath2, genericSinkConfig, Some(testPath2))
+
+    implicit val config = FileStreamingSqlProcessorContext(inputTables, Map(), sinkConfig, testSQL)
+
+    val (streamingQuery, _) = SimpleFileStreamingSqlProcessor.run
+
+    val testMessages = (1 to 4).map(i => f"""{"value": "test-message-$i%02d"} """)
+    testMessages.foreach { message => addFile(message, testFile1) }
+
+    eventually {
+      val writtenData: DataFrame = spark.read.json(testPath2)
+      writtenData.count() shouldBe 1
+    }
+
+    streamingQuery.stop
+  }
+
+  def addFile(text: String, parentFile: File): Unit = {
+    val file = new File(parentFile, f"test-${math.abs(Random.nextLong())}%010d")
+    FileUtils.write(file, text)
+  }
+}
+
+case class TestValueRecord(value: String)

--- a/src/test/scala/org/tupol/spark/tools/SimpleSqlProcessorSpec.scala
+++ b/src/test/scala/org/tupol/spark/tools/SimpleSqlProcessorSpec.scala
@@ -121,7 +121,7 @@ class SimpleSqlProcessorSpec extends FunSuite with Matchers with SharedSparkSess
   }
 
   test("SimpleSqlProcessor.run fails if the input files can not be found") {
-    val filePath1 = new File("/path/that/does/not/exist/nor/it/should/exist/no_name.unknown_extension").getAbsolutePath
+    val filePath1 = new File("/doodely/doo/floppity.flop").getAbsolutePath
     val inputTables = Map(
       "table1" -> FileSourceConfiguration(filePath1, JsonSourceConfiguration())
     )

--- a/src/test/scala/org/tupol/spark/tools/StreamingFormatConverterContextSpec.scala
+++ b/src/test/scala/org/tupol/spark/tools/StreamingFormatConverterContextSpec.scala
@@ -1,0 +1,85 @@
+package org.tupol.spark.tools
+
+import com.typesafe.config.ConfigFactory
+import org.scalatest.{ FunSuite, Matchers }
+import org.tupol.spark.SharedSparkSession
+import org.tupol.spark.io.FormatType.{ Json, Kafka }
+import org.tupol.spark.io.sources.TextSourceConfiguration
+import org.tupol.spark.io.streaming.structured.{ FileStreamDataSinkConfiguration, FileStreamDataSourceConfiguration, GenericStreamDataSinkConfiguration, KafkaStreamDataSinkConfiguration, KafkaStreamDataSourceConfiguration, KafkaSubscription }
+import org.tupol.spark.sql.loadSchemaFromFile
+import org.tupol.spark.testing.files.TestTempFilePath1
+
+class StreamingFormatConverterContextSpec extends FunSuite with Matchers with SharedSparkSession with TestTempFilePath1 {
+
+  val ReferenceSchema = loadSchemaFromFile("src/test/resources/sources/avro/sample_schema.json")
+
+  test("StreamingFormatConverterContext basic creation kafka to kafka ") {
+    val configStr =
+      s"""
+         |input.format=kafka
+         |input.kafka.bootstrap.servers=test_server_in
+         |input.subscription.type="assign"
+         |input.subscription.value="topic_in"
+         |
+         |output.format=kafka
+         |output.kafka.bootstrap.servers=test_server_out
+      """.stripMargin
+    val config = ConfigFactory.parseString(configStr)
+
+    val expectedSource = KafkaStreamDataSourceConfiguration("test_server_in", KafkaSubscription("assign", "topic_in"))
+    val expectedSink = KafkaStreamDataSinkConfiguration("test_server_out", GenericStreamDataSinkConfiguration(Kafka))
+    val expected = StreamingFormatConverterContext(expectedSource, expectedSink)
+
+    val result = StreamingFormatConverterContext(config)
+
+    result.get shouldBe expected
+  }
+
+  test("StreamingFormatConverterContext basic creation kafka to file stream") {
+    val configStr =
+      s"""
+         |input.format=kafka
+         |input.kafka.bootstrap.servers=test_server_in
+         |input.subscription.type="assign"
+         |input.subscription.value="topic_in"
+         |
+         |output.format=json
+         |output.path=my_path
+         |output.options {
+         |   key1: val1
+         |   key2: val2
+         |}
+      """.stripMargin
+    val config = ConfigFactory.parseString(configStr)
+
+    val expectedSource = KafkaStreamDataSourceConfiguration("test_server_in", KafkaSubscription("assign", "topic_in"))
+    val expectedGenericSink = GenericStreamDataSinkConfiguration(Json, Map("key1" -> "val1", "key2" -> "val2"))
+    val expectedSink = FileStreamDataSinkConfiguration("my_path", expectedGenericSink)
+    val expected = StreamingFormatConverterContext(expectedSource, expectedSink)
+
+    val result = StreamingFormatConverterContext(config)
+
+    result.get shouldBe expected
+  }
+
+  test("StreamingFormatConverterContext basic creation file stream to kafka ") {
+    val configStr =
+      s"""
+         |input.format=text
+         |input.path="input_path"
+         |
+         |output.format=kafka
+         |output.kafka.bootstrap.servers=test_server_out
+      """.stripMargin
+    val config = ConfigFactory.parseString(configStr)
+
+    val expectedSource = FileStreamDataSourceConfiguration("input_path", TextSourceConfiguration())
+    val expectedSink = KafkaStreamDataSinkConfiguration("test_server_out", GenericStreamDataSinkConfiguration(Kafka))
+    val expected = StreamingFormatConverterContext(expectedSource, expectedSink)
+
+    val result = StreamingFormatConverterContext(config)
+
+    result.get shouldBe expected
+  }
+
+}

--- a/src/test/scala/org/tupol/spark/tools/StreamingFormatConverterSpec.scala
+++ b/src/test/scala/org/tupol/spark/tools/StreamingFormatConverterSpec.scala
@@ -1,0 +1,94 @@
+package org.tupol.spark.tools
+
+import java.io.File
+
+import net.manub.embeddedkafka.{ EmbeddedKafka, EmbeddedKafkaConfig }
+import org.apache.commons.io.FileUtils
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.streaming.Trigger
+import org.scalatest.concurrent.Eventually
+import org.scalatest.time.{ Seconds, Span }
+import org.scalatest.{ BeforeAndAfter, FunSuite, GivenWhenThen, Matchers }
+import org.tupol.spark.SharedSparkSession
+import org.tupol.spark.io.FormatType
+import org.tupol.spark.io.streaming.structured._
+import org.tupol.spark.testing._
+import org.tupol.spark.testing.files.{ TestTempFilePath1, TestTempFilePath2 }
+
+import scala.util.Random
+
+class StreamingStreamingFormatConverterSpec extends FunSuite
+  with Matchers with GivenWhenThen with Eventually with BeforeAndAfter
+  with SharedSparkSession with EmbeddedKafka
+  with TestTempFilePath1 with TestTempFilePath2 {
+
+  implicit override val patienceConfig = PatienceConfig(timeout = scaled(Span(10, Seconds)))
+
+  test("StreamingFormatConverter basic run test from parquet to json") {
+
+    FileUtils.forceMkdir(testFile1)
+    FileUtils.forceMkdir(testFile2)
+
+    val options = Map[String, String]("path" -> testPath1)
+
+    val inputConfig = GenericStreamDataSourceConfiguration(FormatType.Text, options, None)
+
+    val genericSinkConfig = GenericStreamDataSinkConfiguration(FormatType.Json, Map(), Some("testQuery"),
+      Some(Trigger.ProcessingTime("1 second")))
+    val sinkConfig = FileStreamDataSinkConfiguration(FormatType.Json, testPath2, genericSinkConfig, Some(testPath2))
+
+    implicit val config = StreamingFormatConverterContext(inputConfig, sinkConfig)
+
+    val streamingQuery = StreamingFormatConverter.run
+
+    val testMessages = (1 to 4).map(i => f"test-message-$i%02d")
+
+    testMessages.foreach { message => addFile(message, testFile1) }
+
+    val sourceData = spark.createDataFrame(testMessages.map(x => (x, x))).select("_1").toDF("value")
+
+    eventually {
+      val writtenData: DataFrame = spark.read.json(testPath2)
+      writtenData.comapreWith(sourceData).areEqual(false) shouldBe true
+    }
+
+    streamingQuery.stop
+  }
+
+  test("StreamingFormatConverter basic run test from kafka to json") {
+
+    implicit val config = EmbeddedKafkaConfig()
+    val topic = "testTopic"
+    val inputConfig = KafkaStreamDataSourceConfiguration(
+      s":${config.kafkaPort}", KafkaSubscription("subscribe", topic), Some("earliest")
+    )
+
+    val genericSinkConfig = GenericStreamDataSinkConfiguration(FormatType.Json, Map(), Some("testQuery"),
+      Some(Trigger.ProcessingTime("1 second")))
+    val sinkConfig = FileStreamDataSinkConfiguration(FormatType.Json, testPath2, genericSinkConfig, Some(testPath2))
+
+    implicit val formatterConfig = StreamingFormatConverterContext(inputConfig, sinkConfig)
+
+    withRunningKafka {
+
+      val streamingQuery = StreamingFormatConverter.run
+
+      val testMessages = (1 to 4).map(i => f"test-message-$i%02d")
+      testMessages.foreach { message => publishStringMessageToKafka(topic, message) }
+
+      val sourceData = spark.createDataFrame(testMessages.map(x => (x, x))).select("_1").toDF("value")
+
+      eventually {
+        val writtenData: DataFrame = spark.read.json(testPath2)
+        writtenData.select("value").comapreWith(sourceData).areEqual(false) shouldBe true
+      }
+      streamingQuery.stop
+    }
+
+  }
+
+  def addFile(text: String, parentFile: File): Unit = {
+    val file = new File(parentFile, f"test-${math.abs(Random.nextLong())}%010d")
+    FileUtils.write(file, text)
+  }
+}


### PR DESCRIPTION
-  `FormatConverter` is now extending `SparkFun` instead of `SparkApp` to showcase the new API
- Added tests for the spark 2.4.x built in `avro` support
- Added tests for the spark 2.4.3 built in `delta` support
- Changed the Spark dependency to 2.4.3
- Added `RELEASE-NOTES.md`
- `build.sbt` cleanup & added embedded Kafka support
- added `spark.sql.warehouse.dir` to `SharedSparkSession`
- `FileStreamingSqlProcessor` added `StreamingQuery` to the return of `run`
- `FileStreamingSqlProcessor` added shutdown hook
- `StreamingFormatConverter` added `StreamingQuery` to the return of `run`
- `StreamingFormatConverter` added shutdown hook
- improved unit test coverage